### PR TITLE
feat: playback mode (Use as standalone MIDI sender)

### DIFF
--- a/src/components/encoder-knob.vue
+++ b/src/components/encoder-knob.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="['encoder-knob control', { active }]" ref="root" @mousedown="dragStart">
-        <div class="knob" :style="{ transform: `rotate(${HOME_POSITION + value * DEG_PER_UNIT}deg)` }" />
+        <div class="knob" :style="{ transform: `rotate(${HOME_POSITION + value * MOVEMENT_RANGE}deg)` }" />
         <span class="channel">CH{{ channel }}</span>
         <span class="cc">cc{{ cc }}</span>
     </div>
@@ -28,8 +28,8 @@ const value = defineModel('value', {
     default: 0
 })
 
-// Encoder has 127 units per full revolution
-const DEG_PER_UNIT = 300 / 127
+// Range of movement
+const MOVEMENT_RANGE = 300
 const HOME_POSITION = -150
 
 const root = useTemplateRef('root')
@@ -41,7 +41,7 @@ const { dragStart } = draggable(null, {
             pos[1] - (dims.top + dims.height / 2)
         ]
         const angle = Math.atan2(offset[1], offset[0])
-        value.value = Math.max(0, Math.min(127, mod(angle / Math.PI * 180 - HOME_POSITION + 90, 360) / DEG_PER_UNIT))
+        value.value = Math.max(0, Math.min(1, mod(angle / Math.PI * 180 - HOME_POSITION + 90, 360) / MOVEMENT_RANGE))
     }
 })
 

--- a/src/components/encoder-knob.vue
+++ b/src/components/encoder-knob.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['encoder-knob control', { active }]">
+    <div :class="['encoder-knob control', { active }]" ref="root" @mousedown="dragStart">
         <div class="knob" :style="{ transform: `rotate(${HOME_POSITION + value * DEG_PER_UNIT}deg)` }" />
         <span class="channel">CH{{ channel }}</span>
         <span class="cc">cc{{ cc }}</span>
@@ -7,7 +7,10 @@
 </template>
 
 <script setup>
+import { useTemplateRef } from 'vue'
 import { useActiveFlash } from '@/composables/active-flash.js'
+import draggable from '@/composables/draggable.js'
+import { mod } from '@/util/math.js'
 
 const props = defineProps({
     cc: {
@@ -18,15 +21,29 @@ const props = defineProps({
         type: Number,
         default: 1,
     },
-    value: {
-        type: Number,
-        default: 0,
-    }
+})
+
+const value = defineModel('value', {
+    type: Number,
+    default: 0
 })
 
 // Encoder has 127 units per full revolution
 const DEG_PER_UNIT = 300 / 127
 const HOME_POSITION = -150
+
+const root = useTemplateRef('root')
+const { dragStart } = draggable(null, {
+    onDrag(_, pos) {
+        const dims = root.value.getBoundingClientRect()
+        const offset = [
+            pos[0] - (dims.left + dims.width / 2),
+            pos[1] - (dims.top + dims.height / 2)
+        ]
+        const angle = Math.atan2(offset[1], offset[0])
+        value.value = Math.max(0, Math.min(127, mod(angle / Math.PI * 180 - HOME_POSITION + 90, 360) / DEG_PER_UNIT))
+    }
+})
 
 const { active } = useActiveFlash(() => props.value)
 </script>

--- a/src/components/horizontal-fader.vue
+++ b/src/components/horizontal-fader.vue
@@ -1,20 +1,21 @@
 <template>
-    <div :class="['horizontal-fader control', { active }]">
+    <div :class="['horizontal-fader control', { active }]" ref="root">
         <div class="bg" />
         <div class="track" />
         <span class="channel">CH{{ channel }}</span>
-        <div class="handle" :style="{ left }">
+        <div class="handle" :style="{ left }" @mousedown="dragStart">
             <span class="cc">cc{{ cc }}</span>
         </div>
     </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 
 import { useActiveFlash } from '@/composables/active-flash.js'
+import draggable from '@/composables/draggable.js'
 
-const props = defineProps({
+defineProps({
     cc: {
         type: Number,
         default: 0,
@@ -23,18 +24,27 @@ const props = defineProps({
         type: Number,
         default: 1,
     },
-    value: {
-        type: Number,
-        default: 0
+})
+
+const value = defineModel('value', {
+    type: Number,
+    default: 0
+})
+
+const root = useTemplateRef('root')
+const { dragStart } = draggable(null, {
+    onDrag([x]) {
+        const dims = root.value.getBoundingClientRect()
+        value.value = Math.max(0, Math.min(127, value.value + x / dims.width * (100 / AMOUNT_PER_UNIT)))
     }
 })
 
-const left = computed(() => `${props.value * AMOUNT_PER_UNIT}%`)
+const left = computed(() => `${value.value * AMOUNT_PER_UNIT}%`)
 
-// Fader has 127 units from bottom to top
+// Fader has 127 units from left to right
 const AMOUNT_PER_UNIT = 78 / 127
 
-const { active } = useActiveFlash(() => props.value)
+const { active } = useActiveFlash(() => value.value)
 </script>
 
 <style lang="sass">

--- a/src/components/horizontal-fader.vue
+++ b/src/components/horizontal-fader.vue
@@ -35,14 +35,14 @@ const root = useTemplateRef('root')
 const { dragStart } = draggable(null, {
     onDrag([x]) {
         const dims = root.value.getBoundingClientRect()
-        value.value = Math.max(0, Math.min(127, value.value + x / dims.width * (100 / AMOUNT_PER_UNIT)))
+        value.value = Math.max(0, Math.min(1, value.value + x / dims.width * (100 / MOVEMENT_AREA)))
     }
 })
 
-const left = computed(() => `${value.value * AMOUNT_PER_UNIT}%`)
+const left = computed(() => `${value.value * MOVEMENT_AREA}%`)
 
-// Fader has 127 units from left to right
-const AMOUNT_PER_UNIT = 78 / 127
+// Right 11 and left 11 percent are padding
+const MOVEMENT_AREA = 78
 
 const { active } = useActiveFlash(() => value.value)
 </script>

--- a/src/components/midi-monitor.vue
+++ b/src/components/midi-monitor.vue
@@ -30,13 +30,13 @@ const controller = inject('$controllers')
 const MAX_LOG_SIZE = 50
 const log = reactive([])
 
-function format({ time, name, data }) {
+function format({ time, name, data, direction = 'in' }) {
     const seconds = (Math.round(time) / 1000).toFixed(2)
     if (activeFormat.value === 'hex') {
         const hex = [...data].map(b => b.toString(16).padStart(2, '0'))
         return `${seconds}: [${name}] [${hex.join(' ')}]`
     }
-    return `${seconds}: [${name}] ${formatMIDI(data)}`
+    return `${direction === 'in' ? '▼' : '▲'} ${seconds}: [${name}] ${formatMIDI(data)}`
 }
 
 const FORMATS = [
@@ -48,13 +48,13 @@ function setFormat(type) {
     activeFormat.value = type
 }
 
-controller.addEventListener('action', ({ action, args: [id, name, data] }) => {
+controller.addEventListener('action', ({ action, args: [id, name, data, direction] }) => {
     // Ignore non-log messages
     if (action !== 'log') return
     // Ignore sysex messages
     if ((data[0] & 0xf0) === 0xf0) return
     const time = performance.now()
-    log.unshift({ time, name, data })
+    log.unshift({ time, name, direction, data })
     log.splice(MAX_LOG_SIZE, log.length - MAX_LOG_SIZE)
 })
 </script>

--- a/src/components/midi-monitor.vue
+++ b/src/components/midi-monitor.vue
@@ -12,8 +12,8 @@
         </ul>
         <ol>
             <li
-                v-for="message of log"
-                :key="message.time"
+                v-for="(message, idx) of log"
+                :key="idx"
             >
                 {{ format(message) }}
             </li>

--- a/src/components/push-button.vue
+++ b/src/components/push-button.vue
@@ -14,7 +14,7 @@
 import { computed } from 'vue'
 import { useActiveFlash } from '@/composables/active-flash.js'
 
-const props = defineProps({
+defineProps({
     cc: {
         type: Number,
         default: 0,
@@ -30,15 +30,7 @@ const props = defineProps({
     disabled: {
         type: Boolean,
         default: false,
-    },
-    max: {
-        type: Number,
-        default: 127,
-    },
-    min: {
-        type: Number,
-        default: 0,
-    },
+    }
 })
 
 const value = defineModel('value', {
@@ -46,11 +38,11 @@ const value = defineModel('value', {
     default: 0
 })
 
-const pressed = computed(() => value.value === props.max)
+const pressed = computed(() => value.value)
 const { active } = useActiveFlash(() => pressed.value)
 
 function activate(enabled) {
-    value.value = enabled ? props.max : props.min
+    value.value = enabled ? 1 : 0
 }
 </script>
 

--- a/src/components/push-button.vue
+++ b/src/components/push-button.vue
@@ -2,6 +2,8 @@
     <div
         :class="['push-button control', { active, disabled, pressed }]"
         :style="{ background: `radial-gradient(${color}, ${color} 60%, #111)` }"
+        @pointerdown="activate(true)"
+        @pointerup="activate(false)"
     >
         <span class="channel" v-if="!disabled">CH{{ channel }}</span>
         <span class="cc" v-if="!disabled">cc{{ cc }}</span>
@@ -9,6 +11,7 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { useActiveFlash } from '@/composables/active-flash.js'
 
 const props = defineProps({
@@ -28,13 +31,27 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
-    pressed: {
-        type: Boolean,
-        default: false
-    }
+    max: {
+        type: Number,
+        default: 127,
+    },
+    min: {
+        type: Number,
+        default: 0,
+    },
 })
 
-const { active } = useActiveFlash(() => props.pressed)
+const value = defineModel('value', {
+    type: Number,
+    default: 0
+})
+
+const pressed = computed(() => value.value === props.max)
+const { active } = useActiveFlash(() => pressed.value)
+
+function activate(enabled) {
+    value.value = enabled ? props.max : props.min
+}
 </script>
 
 <style lang="sass">

--- a/src/components/vertical-fader.vue
+++ b/src/components/vertical-fader.vue
@@ -1,20 +1,21 @@
 <template>
-    <div :class="['vertical-fader control', { active }]">
+    <div :class="['vertical-fader control', { active }]" ref="root">
         <div class="bg" />
         <div class="track" />
         <span class="channel">CH{{ channel }}</span>
-        <div class="handle" :style="{ bottom }">
+        <div class="handle" :style="{ bottom }" @mousedown="dragStart">
             <span class="cc">cc{{ cc }}</span>
         </div>
     </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 
 import { useActiveFlash } from '@/composables/active-flash.js'
+import draggable from '@/composables/draggable.js'
 
-const props = defineProps({
+defineProps({
     cc: {
         type: Number,
         default: 0,
@@ -22,16 +23,25 @@ const props = defineProps({
     channel: {
         type: Number,
         default: 1,
-    },
-    value: {
-        type: Number,
-        default: 0
     }
 })
 
-const bottom = computed(() => `${props.value * AMOUNT_PER_UNIT}%`)
+const value = defineModel('value', {
+    type: Number,
+    default: 0
+})
 
-const { active } = useActiveFlash(() => props.value)
+const root = useTemplateRef('root')
+const { dragStart } = draggable(null, {
+    onDrag([, y]) {
+        const dims = root.value.getBoundingClientRect()
+        value.value = Math.max(0, Math.min(127, value.value - y / dims.height * (100 / AMOUNT_PER_UNIT)))
+    }
+})
+
+const bottom = computed(() => `${value.value * AMOUNT_PER_UNIT}%`)
+
+const { active } = useActiveFlash(() => value.value)
 
 // Fader has 127 units from bottom to top
 const AMOUNT_PER_UNIT = 86 / 127

--- a/src/components/vertical-fader.vue
+++ b/src/components/vertical-fader.vue
@@ -35,16 +35,16 @@ const root = useTemplateRef('root')
 const { dragStart } = draggable(null, {
     onDrag([, y]) {
         const dims = root.value.getBoundingClientRect()
-        value.value = Math.max(0, Math.min(127, value.value - y / dims.height * (100 / AMOUNT_PER_UNIT)))
+        value.value = Math.max(0, Math.min(1, value.value - y / dims.height * (100 / MOVEMENT_AREA)))
     }
 })
 
-const bottom = computed(() => `${value.value * AMOUNT_PER_UNIT}%`)
+const bottom = computed(() => `${value.value * MOVEMENT_AREA}%`)
 
 const { active } = useActiveFlash(() => value.value)
 
-// Fader has 127 units from bottom to top
-const AMOUNT_PER_UNIT = 86 / 127
+// Top 7 and bottom 7 percent are padding
+const MOVEMENT_AREA = 86 // percent
 </script>
 
 <style lang="sass">

--- a/src/composables/draggable.js
+++ b/src/composables/draggable.js
@@ -33,10 +33,11 @@ export default function draggable(elRef, { button = 0, onDragStart, onDrag, onDr
         window.removeEventListener('mouseup', dragEnd)
     }
     onMounted(() => {
-        elRef.value.addEventListener('mousedown', dragStart)
+        if (elRef) elRef.value.addEventListener('mousedown', dragStart)
     })
 
     return {
-        dragging
+        dragging,
+        dragStart,
     }
 }

--- a/src/pages/home.vue
+++ b/src/pages/home.vue
@@ -68,7 +68,7 @@
     <main>
         <div class="wrapper">
             <notifier ref="notifications" />
-            <div :class="['device', waitingForMode, { waitingForMode }]">
+            <div :class="['device', waitingForMode, { waitingForMode, playbackMode }]">
                 <div class="section encoders">
                     <div class="group">
                         <select
@@ -102,6 +102,7 @@
                             v-bind="encoder"
                             @pointerdown="select(encoder, 'encoder', $event)"
                             @contextmenu.ctrl.prevent
+                            :value="((encoder.value || 0) - encoder.min) / (encoder.max - encoder.min)"
                             @update:value="setControlValue(encoder, 'encoder', $event)"
                         />
                         <push-button
@@ -109,7 +110,7 @@
                             :pressed="button.value === button.max"
                             @pointerdown="select(button, 'button', $event)"
                             @contextmenu.ctrl.prevent
-                            v-model:value="button.value"
+                            :value="button.value === button.max ? 1 : 0"
                             @update:value="setControlValue(button, 'button', $event)"
                         />
                     </div>
@@ -121,6 +122,7 @@
                             :class="{ modified: hasChanged(fader), editing: editSelection.some(c => c.parameters === fader) }"
                             :key="idx"
                             v-bind="fader"
+                            :value="((fader.value || 0) - fader.min) / (fader.max - fader.min)"
                             @pointerdown="select(fader, 'fader', $event)"
                             @contextmenu.ctrl.prevent
                             @update:value="setControlValue(fader, 'fader', $event)"
@@ -137,7 +139,7 @@
                             @pointerdown="select(currentGroup.xFader, 'fader', $event)"
                             @contextmenu.ctrl.prevent
                             v-bind="currentGroup.xFader"
-                            v-model:value="currentGroup.xFader.value"
+                            :value="((currentGroup.xFader.value || 0) - currentGroup.xFader.min) / (currentGroup.xFader.max - currentGroup.xFader.min)"
                             @update:value="setControlValue(currentGroup.xFader, 'fader', $event)"
                         />
                         <push-button
@@ -154,7 +156,7 @@
                             @pointerdown="select(button, 'button', $event)"
                             @contextmenu.ctrl.prevent
                             color="#0a6"
-                            v-model:value="button.value"
+                            :value="button.value === button.max ? 1 : 0"
                             @update:value="setControlValue(button, 'button', $event)"
                         />
                     </div>
@@ -337,7 +339,7 @@ function toggleMIDIMonitor() {
     showMIDIMonitor.value = !showMIDIMonitor.value
 }
 
-const playbackMode = ref(false)
+const playbackMode = ref(true)
 function togglePlaybackMode() {
     playbackMode.value = !playbackMode.value
 }
@@ -435,18 +437,27 @@ function recv({ action, args }) {
 
 /* MIDI sending */
 
-const TYPES = {
-    button: {
-        1: ''
-    }
-}
-
 function setControlValue(control, controlType, value) {
-    control.value = value
+    control.value = control.min + value * (control.max - control.min)
     if (!playbackMode.value) return
-    const realValue = Math.round(control.min + value * (control.max - control.min))
-    console.log(realValue)
-    controllers.send(control)
+    // Determine type of MIDI message to send
+    let type = 'CC'
+    if (controlType === 'button') {
+        switch (control.type) {
+            case 0:
+                return
+            case 1:
+                type = control.value === control.max ? 'NOTE_ON' : 'NOTE_OFF'
+                break
+            case 3:
+                type = 'PC'
+                break
+            case 4:
+                type = 'AFTERTOUCH'
+                break
+        }
+    }
+    controllers.send({ ...control, type })
 }
 
 function changeGroup(e) {
@@ -727,6 +738,10 @@ main
         padding: .5rem
         border-radius: .5rem
         position: relative
+        &.playbackMode
+            .control
+                &:hover
+                    outline: none
         &.waitingForMode
             .faders, .horizontal-fader, .green-buttons, .encoder-wrapper, .group
                 transition: opacity .3s

--- a/src/pages/home.vue
+++ b/src/pages/home.vue
@@ -28,6 +28,15 @@
                     <span>Save</span>
                 </button>
             </li>
+            <li :class="['playback', { active: playbackMode }]">
+                <button
+                    type="button"
+                    @click="togglePlaybackMode"
+                    title="Playback Mode (Emit MIDI events when touching controls)"
+                >
+                    <span>Playback Mode</span>
+                </button>
+            </li>
         </ul>
         <h1>Faderfox UC4 Configurator</h1>
         <aside :class="['monitor', { active: showMIDIMonitor }]">
@@ -93,18 +102,15 @@
                             v-bind="encoder"
                             @pointerdown="select(encoder, 'encoder', $event)"
                             @contextmenu.ctrl.prevent
-                            v-model:cc="encoder.cc"
-                            v-model:min="encoder.min"
-                            v-model:max="encoder.max"
-                            v-model:channel="encoder.channel"
+                            @update:value="setControlValue(encoder, 'encoder', $event)"
                         />
                         <push-button
                             :class="{ modified: hasChanged(button), editing: editSelection.some(c => c.parameters === button) }"
                             :pressed="button.value === button.max"
                             @pointerdown="select(button, 'button', $event)"
                             @contextmenu.ctrl.prevent
-                            v-model:channel="button.channel"
-                            v-model:cc="button.cc"
+                            v-model:value="button.value"
+                            @update:value="setControlValue(button, 'button', $event)"
                         />
                     </div>
                 </div>
@@ -117,10 +123,7 @@
                             v-bind="fader"
                             @pointerdown="select(fader, 'fader', $event)"
                             @contextmenu.ctrl.prevent
-                            v-model:cc="fader.cc"
-                            v-model:min="fader.min"
-                            v-model:max="fader.max"
-                            v-model:channel="fader.channel"
+                            @update:value="setControlValue(fader, 'fader', $event)"
                         />
                     </div>
                     <div class="cross-fader">
@@ -134,10 +137,8 @@
                             @pointerdown="select(currentGroup.xFader, 'fader', $event)"
                             @contextmenu.ctrl.prevent
                             v-bind="currentGroup.xFader"
-                            v-model:cc="currentGroup.xFader.cc"
-                            v-model:min="currentGroup.xFader.min"
-                            v-model:max="currentGroup.xFader.max"
-                            v-model:channel="currentGroup.xFader.channel"
+                            v-model:value="currentGroup.xFader.value"
+                            @update:value="setControlValue(currentGroup.xFader, 'fader', $event)"
                         />
                         <push-button
                             class="shift"
@@ -153,9 +154,8 @@
                             @pointerdown="select(button, 'button', $event)"
                             @contextmenu.ctrl.prevent
                             color="#0a6"
-                            :pressed="button.value === button.max"
-                            v-model:cc="button.cc"
-                            v-model:channel="button.channel"
+                            v-model:value="button.value"
+                            @update:value="setControlValue(button, 'button', $event)"
                         />
                     </div>
                 </div>
@@ -337,6 +337,11 @@ function toggleMIDIMonitor() {
     showMIDIMonitor.value = !showMIDIMonitor.value
 }
 
+const playbackMode = ref(false)
+function togglePlaybackMode() {
+    playbackMode.value = !playbackMode.value
+}
+
 const learnMode = ref('')
 function toggleLearn(deviceID) {
     learnMode.value = learnMode.value === deviceID ? null : deviceID
@@ -347,6 +352,8 @@ const pos = ref([0, 0])
 const showEditWindow = ref(false)
 const editSelection = ref([])
 function select(parameters, type, e) {
+    // Don't select when in playback mode
+    if (playbackMode.value) return
     e.stopPropagation()
     // Multiple select
     if (e.shiftKey || e.ctrlKey) {
@@ -424,6 +431,22 @@ function recv({ action, args }) {
         cancelMode()
         notifications.value.notify({ text: 'Configuration Received Successfully' })
     }
+}
+
+/* MIDI sending */
+
+const TYPES = {
+    button: {
+        1: ''
+    }
+}
+
+function setControlValue(control, controlType, value) {
+    control.value = value
+    if (!playbackMode.value) return
+    const realValue = Math.round(control.min + value * (control.max - control.min))
+    console.log(realValue)
+    controllers.send(control)
 }
 
 function changeGroup(e) {
@@ -585,6 +608,11 @@ header
                 color: #fff
         .load button:before
             content: '\f07c'
+        .playback
+            button:before
+                content: '\f04b'
+            &.active button
+                background: #050
         .new button:before
             content: '\f15b'
         .save button:before

--- a/src/services/controllers/manager.js
+++ b/src/services/controllers/manager.js
@@ -22,20 +22,20 @@ export class ControllerManager extends EventTarget {
             device.destroy()
         }
     }
-    indicate(...args) {
-        const tasks = []
-        for (const device of this.attachedDevices) {
-            if (!device.indicate) continue
-            tasks.push(device.indicate(...args))
-        }
-        return Promise.all(tasks)
-    }
     init() {
         for (const deviceType of HARDWARE_TYPES) {
             deviceType.addEventListener('connect', this.#onConnect.bind(this))
             deviceType.addEventListener('disconnect', this.#onDisconnect.bind(this))
             deviceType.monitor()
         }
+    }
+    send(...args) {
+        const tasks = []
+        for (const device of this.attachedDevices) {
+            if (!device.send) continue
+            tasks.push(device.send(...args))
+        }
+        return Promise.all(tasks)
     }
     #onConnect({ device }) {
         if (this.attachedDevices.find(d => d.id === device.id)) return
@@ -50,14 +50,5 @@ export class ControllerManager extends EventTarget {
         device.removeEventListener('action', this.#actionDelegator)
         this.attachedDevices.splice(index, 1)
         console.warn(`Disconnected ${device.name}`)
-    }
-    // Reconfigure controllers when mission changes
-    configure(...args) {
-        const tasks = []
-        for (const device of this.attachedDevices) {
-            if (!device.configure) continue
-            tasks.push(device.configure(...args))
-        }
-        return Promise.all(tasks)
     }
 }

--- a/src/services/controllers/midi/base.js
+++ b/src/services/controllers/midi/base.js
@@ -3,7 +3,11 @@ import { BaseController } from '../base.js'
 const MIDI_COMMANDS = {
     NOTE_OFF: 0x80,
     NOTE_ON: 0x90,
+    PKP: 0xa0,
     CC: 0xb0,
+    PC: 0xc0,
+    AFTERTOUCH: 0xd0,
+    PITCH_BEND: 0xe0,
     SYSEX: 0xf0,
 }
 
@@ -22,7 +26,7 @@ export class MIDIDevice extends BaseController {
         this.input.removeEventListener('midimessage', this.#receiver)
     }
     receive({ data }) {
-        this.emit({ action: 'log', args: [this.id, this.name, data] })
+        this.emit({ action: 'log', args: [this.id, this.name, data, 'in'] })
         const [command, eventCode, value] = data
         const commandType = command & 0xf0
         const channel = command & 0x0f
@@ -36,11 +40,16 @@ export class MIDIDevice extends BaseController {
         return data
     }
     send({ type = 'CC', channel, cc, value }) {
-        const msg = new Uint8Array(3)
+        const msg = new Uint8Array(type === 'PC' || type === 'AFTERTOUCH' ? 2 : 3)
         msg[0] = MIDI_COMMANDS[type] + channel - 1
-        msg[1] = cc
-        msg[2] = value
-        this.emit({ action: 'log', args: [this.id, this.name, msg] })
+        // Program changes are only 2 bytes
+        if (type === 'PC' || type === 'AFTERTOUCH') {
+            msg[1] = Math.round(value)
+        } else {
+            msg[1] = cc
+            msg[2] = Math.round(value)
+        }
+        this.emit({ action: 'log', args: [this.id, this.name, msg, 'out'] })
         this.output.send(msg)
     }
 }

--- a/src/services/controllers/midi/base.js
+++ b/src/services/controllers/midi/base.js
@@ -35,4 +35,12 @@ export class MIDIDevice extends BaseController {
         }
         return data
     }
+    send({ type = 'CC', channel, cc, value }) {
+        const msg = new Uint8Array(3)
+        msg[0] = MIDI_COMMANDS[type] + channel - 1
+        msg[1] = cc
+        msg[2] = value
+        this.emit({ action: 'log', args: [this.id, this.name, msg] })
+        this.output.send(msg)
+    }
 }

--- a/src/services/controllers/midi/controller.js
+++ b/src/services/controllers/midi/controller.js
@@ -54,4 +54,7 @@ export class MIDIController extends EventTarget {
         access.addEventListener('statechange', ({ port }) => this.processPort(port))
         this.discover(access)
     }
+    send() {
+        console.log(this.devices)
+    }
 }

--- a/src/services/controllers/midi/uc4.js
+++ b/src/services/controllers/midi/uc4.js
@@ -14,9 +14,9 @@ export class FaderfoxUC4 extends MIDIDevice {
     }
     load(config) {
         const buff = setupCodec.encode(config)
-        return this.send(buff)
+        return this.sendRaw(buff)
     }
-    send(buff) {
+    sendRaw(buff) {
         this.output.send(buff)
     }
 }

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -1,7 +1,11 @@
 const MIDI_COMMANDS = {
     NOTE_OFF: 0x80,
     NOTE_ON: 0x90,
+    PKP: 0xa0,
     CC: 0xb0,
+    PC: 0xc0,
+    AFTERTOUCH: 0xd0,
+    PITCH_BEND: 0xe0,
     SYSEX: 0xf0,
 }
 const COMMAND_MAP = {}
@@ -11,7 +15,7 @@ export function decodeMIDI(data) {
     const command = data[0] & 0xf0
     const channel = (data[0] & 0x0f) + 1
     const cc = data[1]
-    const value = data[2]
+    const value = data[2] ?? ''
     return { command, channel, cc, value }
 }
 

--- a/src/util/math.js
+++ b/src/util/math.js
@@ -1,0 +1,4 @@
+// Helper function for doing a "proper" modulo (I.E. including negative values)
+export function mod(n, m) {
+    return (n % m + m) % m
+}


### PR DESCRIPTION
Adds "playback mode", which allows a user to interact with all the controls using a mouse and sending out MIDI events to external devices, emulating the UC4 as a software-only version.

Misc:
 - fix: support reading and writing pitch bend, program change and aftertouch MIDI messages 